### PR TITLE
Fix/Missing faces cut by the video border

### DIFF
--- a/stack/lambdas/rekopoc-apply-faces-to-video-docker/video_processor.py
+++ b/stack/lambdas/rekopoc-apply-faces-to-video-docker/video_processor.py
@@ -64,8 +64,8 @@ def apply_faces_to_video(final_timestamps, local_path_to_video, local_output, vi
                 upper_bound = int(int(t) / 1000 * frame_rate + frame_rate / 2) + 1
                 if (frame_counter >= lower_bound) and (frame_counter <= upper_bound):
                     for f in faces:
-                        x = int(f['Left'] * frame_width) - width_delta
-                        y = int(f['Top'] * frame_height) - height_delta
+                        x = max(int(f['Left'] * frame_width) - width_delta,0)
+                        y = max(int(f['Top'] * frame_height) - height_delta,0)
                         w = int(f['Width'] * frame_width) + 2 * width_delta
                         h = int(f['Height'] * frame_height) + 2 * height_delta
 


### PR DESCRIPTION
Updated x and y values of faces to make sure they are not a negative number

*Issue #, if available:*
The code is not able to blur faces that were cut by the upper video border line. 

*Description of changes:*
Investigations showed that for such cases, function apply_faces_to_video of [this file](
https://github.com/aws-samples/rekognition-video-people-blurring-cdk/blob/2fa808f256811636e3ba8977b39f71aca5a2f8dc/stack/lambdas/rekopoc-apply-faces-to-video-docker/video_processor.py) was returning a negative value for variables x and y leading to a corruption in the blurring function and thus resulting in an unblurred face.
I fixed that on my code by taking the maximum value between 0 and the original variable value.
`x = max(int(f['Left'] * frame_width) - width_delta,0)`
`y = max(int(f['Top'] * frame_height) - height_delta,0)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
