### PR TITLE
Fixing Lambda runtime CDK Error

### DIFF
--- a/stack/rekognition_video_face_blurring_cdk_stack.py
+++ b/stack/rekognition_video_face_blurring_cdk_stack.py
@@ -35,7 +35,7 @@ class RekognitionVideoFaceBlurringCdkStack(Stack):
             memory_size=512,
             code=lambda_.Code.from_asset('./stack/lambdas/rekopoc-start-face-detect'),
             handler="lambda_function.lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_7
+            runtime=lambda_.Runtime.PYTHON_3_10
         )
 
         #Adding S3 event sources triggers for the startFaceDetectFunction, allowing .mov and .mp4 files only
@@ -73,7 +73,7 @@ class RekognitionVideoFaceBlurringCdkStack(Stack):
             memory_size=512,
             code=lambda_.Code.from_asset('./stack/lambdas/rekopoc-check-status'),
             handler="lambda_function.lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_7
+            runtime=lambda_.Runtime.PYTHON_3_10
         )
 
         #Allowing checkStatusFunction to call Rekognition
@@ -90,7 +90,7 @@ class RekognitionVideoFaceBlurringCdkStack(Stack):
             memory_size=512,
             code=lambda_.Code.from_asset('./stack/lambdas/rekopoc-get-timestamps-faces'),
             handler="lambda_function.lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12
+            runtime=lambda_.Runtime.PYTHON_3_10
         )
 
         #Allowing getTimestampsFunction to call Rekognition

--- a/stack/rekognition_video_face_blurring_cdk_stack.py
+++ b/stack/rekognition_video_face_blurring_cdk_stack.py
@@ -90,7 +90,7 @@ class RekognitionVideoFaceBlurringCdkStack(Stack):
             memory_size=512,
             code=lambda_.Code.from_asset('./stack/lambdas/rekopoc-get-timestamps-faces'),
             handler="lambda_function.lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_7
+            runtime=lambda_.Runtime.PYTHON_3_12
         )
 
         #Allowing getTimestampsFunction to call Rekognition


### PR DESCRIPTION
*Issue #, if available:*
 ❌ Deployment failed: Error: The stack named RekognitionVideoFaceBlurringCdkStack failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: Resource handler returned message: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: cd04a353-5d2e-4f1d-8966-e0e0df8fabcd)" (RequestToken: 14b1cde0-bdab-3908-8924-6f82c39c9281, HandlerErrorCode: InvalidRequest)
*Description of changes:*
Updated All Lambda runtimes from Python 3.7 to 3.10.

